### PR TITLE
changed artwork to point to the correct arrow icon folder, not the faux USDWS one

### DIFF
--- a/_sass/timeline.scss
+++ b/_sass/timeline.scss
@@ -121,7 +121,7 @@ $timeline-right-padding: 5rem;
     // setup accordion arrow
     button {
       background-color: $color-white;
-      background-image: url('../uswds/img/arrow-up.svg');
+      background-image: url('../img/arrow-up.svg');
       background-position: right 2.25rem top 2.9rem;
       border: 1px solid transparent;
       font-family: $font-serif;
@@ -135,7 +135,7 @@ $timeline-right-padding: 5rem;
         box-shadow: none;
       }
       &[aria-expanded='false'] {
-        background-image: url('../uswds/img/arrow-down.svg');
+        background-image: url('../img/arrow-down.svg');
       }
     }
     // inactive step button


### PR DESCRIPTION
Fix arrows so they match (see screenshot for mismatched arrows) and also point to the preferred img asset folder:

<img width="865" alt="screen shot 2017-06-21 at 3 51 20 pm" src="https://user-images.githubusercontent.com/471514/27403741-87677464-5699-11e7-9cfd-96a73864f0d2.png">



[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/apply-arrows/apply/)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/apply-arrows/apply/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/apply-arrows/README.md)

Changes proposed in this pull request:
- corrected img path on the timeline stylesheet

/cc @line47 
