### PR TITLE
Contact page (styled)

### DIFF
--- a/_includes/program-directors.html
+++ b/_includes/program-directors.html
@@ -1,13 +1,20 @@
 <ul class="pd-list">
   {% for topic in site.data.tech-topics %}
     {% for programDirector in topic.programDirector %}
-      <li>
+      <li class="pd-card">
         {% if programDirector.photo %}
           <img src="{{ site.baseurl }}/assets/img/pd/{{ programDirector.photo }}">
         {% endif %}
         <span class="pd-list-content">
-          <h3 class="pd-name"><a href="mailto:{{ programDirector.email }}">{{ programDirector.name }}</a></h3>
-          <span class="pd-tech-topic add-arrow">{{ topic.topic }}</span>
+          <h3 class="pd-name">{{ programDirector.name }}</h3>
+
+          <ul class="pd-topic-list">
+            <li class="pd-tech-topic"><a href="{{ site.baseurl }}{{ topic.permalink }}">{{ topic.topic }}</a></li>
+          </ul>
+
+          <p class="text-small">
+            <a href="mailto:{{ programDirector.email }}">Send email</a>
+          </p>
         </span>
       </li>
     {% endfor %}

--- a/_sass/program-directors.scss
+++ b/_sass/program-directors.scss
@@ -17,7 +17,6 @@
     width: 27rem;
     height: 45rem;
     background-color: $color-white;
-    border: 1px solid #ddd;
   }
 
   .pd-list-content {

--- a/_sass/program-directors.scss
+++ b/_sass/program-directors.scss
@@ -1,7 +1,6 @@
 .pd-list {
   display: flex;
   flex-flow: row wrap;
-  // justify-content: space-between;
   list-style: none;
   margin: $space-xl 0;
   padding: 0;
@@ -13,7 +12,6 @@
 
   .pd-card {
     margin: 0 $space-l $space-l 0;
-    // width: 30%;
     width: 27rem;
     height: 45rem;
     background-color: $color-white;

--- a/_sass/program-directors.scss
+++ b/_sass/program-directors.scss
@@ -1,9 +1,9 @@
 .pd-list {
   display: flex;
   flex-flow: row wrap;
-  justify-content: space-between;
+  // justify-content: space-between;
   list-style: none;
-  margin: 0;
+  margin: $space-xl 0;
   padding: 0;
 
   img {
@@ -11,9 +11,13 @@
     max-width: 100%;
   }
 
-  li {
-    margin-bottom: 12rem;
-    width: 30%;
+  .pd-card {
+    margin: 0 $space-l $space-l 0;
+    // width: 30%;
+    width: 27rem;
+    height: 45rem;
+    background-color: $color-white;
+    border: 1px solid #ddd;
   }
 
   .pd-list-content {
@@ -23,6 +27,40 @@
 }
 
 .pd-name {
-  font-size: 2rem;
+  font-size: $font-size-xs;
+  margin-top: $space-m;
+  margin-bottom: $space-m;
+  letter-spacing: normal;
+
+}
+
+.pd-topic-list {
+  list-style: none;
+  padding: 0;
+  margin-bottom: $space-m;
+
+  .pd-tech-topic {
+    font-size: $font-size-xxs;
+    line-height: $leading-xs;
+    margin-bottom: $space-xs;
+
+    &::before {
+      content: '\2192';
+      font-family: $font-serif;
+      margin-left: -16px;
+      width: 16px;
+      color: $color-base;
+    }
+
+    a {
+      color: $color-primary;
+      font-weight: 500;
+      display: block;
+      border: none;
+      margin: -1.6rem 0 0 0;
+    }
+
+
+  }
 
 }

--- a/_sass/site.scss
+++ b/_sass/site.scss
@@ -91,4 +91,9 @@
   &:visited {
     color: $color-visited;
   }
+
+  &:active,
+  &:focus {
+    box-shadow: none;
+  }
 }

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css?family=Chivo:400,700|Work+Sans:400,500,600,700,800');
 
+h1,
 .page-title {
   font-size: $font-size-xl;
   font-weight: 800;

--- a/_sass/uswds-overrides.scss
+++ b/_sass/uswds-overrides.scss
@@ -95,6 +95,13 @@ button:visited,
     background-color: $color-primary-alt;
   }
 
+  &.usa-button-active,
+  &:active,
+  &.usa-button-focus,
+  &:focus {
+    box-shadow: none;
+  }
+
 
   &.usa-button-secondary {
     border: 0;

--- a/_sass/utility.scss
+++ b/_sass/utility.scss
@@ -1,0 +1,13 @@
+.utility-content {
+
+  h1 {
+    margin-bottom: $space-xl;
+  }
+
+  h2 {
+    font-size: $font-size-s;
+    font-weight: 600;
+    margin: $space-xl 0 $space-s+$space-xs 0;
+  }
+
+}

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -15,6 +15,7 @@
 @import 'footer';
 @import 'navigation';
 @import 'awardees';
+@import 'utility';
 @import 'site';
 @import 'showcase';
 @import 'tables';

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -10,11 +10,13 @@ layout: secondary-narrow
 
 Have a general question or concern? Call our help line at 703-292-8050 or email us at [sbir@nsf.gov](mailto:sbir@nsf.gov).
 
-Need to contact a program director? View our [program director listing here]({{ sitebase.url }}/about/#meet-our-program-directors).
-
 If you’re concerned about fraud or abuse with any award, contact the NSF Office of the Inspector General at 703-292-7100 (business hours) or 703-244-4443 (to speak to the duty officer).
 
 You can also report fraud to the anonymous fraud hotline at 800-428-2189, email [oig@nsf.gov](mailto:oig@nsf.gov), or send written correspondence to 4201 Wilson Boulevard, Suite 1135; Arlington, VA 22230; ATTN: OIG HOTLINE.
+
+## Report an issue
+
+Notice something wrong with the site or want to make a recommendation? Open an issue in our [GitHub repository](https://github.com/18F/nsf-sbir/issues). Please provide a detailed description of the problem you encountered (along with screenshots and steps we can take to reproduce the error) or the change you're suggesting — we'll respond as quickly as we can.
 
 ## Program directors
 Our program directors are domain experts from diverse fields — get to know them here.

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -25,11 +25,13 @@ Notice something wrong with the site or want to make a recommendation? Open an i
 </div>
 </section>
 
-<section class="usa-section background-light-warm-gray">
-<div class="usa-content utility-content usa-grid">
+<section class="usa-section background-light-blue">
+<div class="usa-content usa-grid">
 <div class="usa-content usa-width-one-whole" markdown="1">
 
-Our program directors are domain experts from diverse fields — get to know them here.
+### Program directors
+
+Our program directors are domain experts from diverse fields — get to know them here. You can also view the [full bios of all of our program directors](https://www.nsfiipconf.com/2017sbirp2/our-team/).
 
 {% include program-directors.html %}
 

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -1,24 +1,38 @@
 ---
 title: Contact
 permalink: /contact/
-layout: secondary-narrow
+layout: secondary
 ---
+
+<section class="usa-section">
+<div class="usa-content utility-content usa-grid">
+<div class="usa-width-one-whole" markdown="1">
 
 # Contact
 
-## Get in touch
-
+## General questions or concerns
 Have a general question or concern? Call our help line at 703-292-8050 or email us at [sbir@nsf.gov](mailto:sbir@nsf.gov).
 
+## Award fraud or abuse
 If you’re concerned about fraud or abuse with any award, contact the NSF Office of the Inspector General at 703-292-7100 (business hours) or 703-244-4443 (to speak to the duty officer).
 
-You can also report fraud to the anonymous fraud hotline at 800-428-2189, email [oig@nsf.gov](mailto:oig@nsf.gov), or send written correspondence to 4201 Wilson Boulevard, Suite 1135; Arlington, VA 22230; ATTN: OIG HOTLINE.
+You can also report fraud to the anonymous fraud hotline at 800-428-2189, email [oig@nsf.gov](mailto:oig@nsf.gov), or send written correspondence to 4201 Wilson Boulevard, Suite 1135; Arlington, VA 22230; ATTN: OIG hotline.
 
-## Report an issue
+## Site feedback
+Notice something wrong with the site or want to make a recommendation? Open an issue in our [GitHub repository](https://github.com/18F/nsf-sbir/issues/new). Please provide a detailed description of the problem you encountered (along with screenshots and steps we can take to reproduce the error) or the change you're suggesting — we'll respond as quickly as we can.
 
-Notice something wrong with the site or want to make a recommendation? Open an issue in our [GitHub repository](https://github.com/18F/nsf-sbir/issues). Please provide a detailed description of the problem you encountered (along with screenshots and steps we can take to reproduce the error) or the change you're suggesting — we'll respond as quickly as we can.
+</div>
+</div>
+</section>
 
-## Program directors
+<section class="usa-section background-light-warm-gray">
+<div class="usa-content utility-content usa-grid">
+<div class="usa-content usa-width-one-whole" markdown="1">
+
 Our program directors are domain experts from diverse fields — get to know them here.
 
 {% include program-directors.html %}
+
+</div>
+</div>
+</section>

--- a/pages/landing.md
+++ b/pages/landing.md
@@ -83,7 +83,7 @@ Learn about our impact
 <div class="usa-width-one-half" markdown="1">
 <h2 class="text-large">We embrace diversity</h2>
 
-We value diversity. Our program fosters and encourages participation in innovation and entrepreneurship by women and people of color as well as first-time entrepreneurs from all 50 states and U.S. territories.
+Our program fosters and encourages participation in innovation and entrepreneurship by women and people of color as well as first-time entrepreneurs from all 50 states and U.S. territories.
 
 <a class="usa-button usa-button-primary button-arrow" href="#">
 What we look for


### PR DESCRIPTION
Fixes issue(s) #484 .

[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/contact/contact/)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/contact/contact/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/contact/contact/README.md)

Changes proposed in this pull request:
- added utility.scss styles for handling pages with non-editorial, utility content 
- changed links to point to tech topic pages instead of invoking email
- re-styled the PD topic areas into bulleted lists to accommodate PDs with more than one topic area (Note: still needs to de-duplicate program directors with multiple topic areas — in this case, Rick Schwerdtferger — and list all topic areas in a single card.)
- Note to @kategarklavs: Program director blurb currently says "get to know them here" but instead of getting to know them _here_ we actually direct users to another page.

/cc @line47 @gemfarmer 
