### PR TITLE
Fixing typo

### DIFF
--- a/pages/awardees/supplement.md
+++ b/pages/awardees/supplement.md
@@ -59,7 +59,7 @@ Check out our [supplemental funding overview video](https://youtu.be/biB6A2Cu6TA
 - Max funding: 20% of the Phase II award amount for no more than one year
 - [More information](http://www.nsf.gov/pubs/2015/nsf15043/nsf15043.jsp)
 
-### Educational parnterships
+### Educational partnerships
 1. High school participants (RAHSS)
 - Funding support to allow high school students to participate in SBIR/STTR research. These partnerships are targeted toward students who are interested in science, technology, and mathematics.
 - Max funding: $6,000 per student per year


### PR DESCRIPTION
Fixing a misspelling that I noticed during today's PR review.

Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
-
-
-

/cc @relevant-people
