### PR TITLE
Clean up banner

### DIFF
--- a/_data/awards_meta.yml
+++ b/_data/awards_meta.yml
@@ -25,7 +25,7 @@ printFields:
 - piLastName
 - piPhone
 - piEmail
-last_updated: 06/23/2017
-active_date: 06/23/2017
+last_updated: 06/26/2017
+active_date: 06/26/2017
 ---
 

--- a/_data/topics_meta.yml
+++ b/_data/topics_meta.yml
@@ -25,6 +25,6 @@ printFields:
 - piLastName
 - piPhone
 - piEmail
-last_updated: 06/23/2017
+last_updated: 06/26/2017
 ---
 

--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -1,7 +1,7 @@
 <div class="usa-banner">
   <div class="usa-accordion">
     <header class="usa-banner-header">
-      <div class="usa-grid usa-banner-inner">
+      <div class="usa-grid usa-banner-inner flex flex-center flex-column">
         <div class="banner-right flex flex-center">
           <img src="{{ site.baseurl }}/assets/uswds/img/favicons/favicon-57.png" alt="U.S. flag">
           <p>An official website of the United States government</p>

--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -2,9 +2,11 @@
   <div class="usa-accordion">
     <header class="usa-banner-header">
       <div class="usa-grid usa-banner-inner">
-      <p class="banner-right">An official website of the United States government</p>
-      <img src="{{ site.baseurl }}/assets/uswds/img/favicons/favicon-57.png" alt="U.S. flag" class="banner-right">
-      <p>This site is currently in <a href="https://18f.gsa.gov/dashboard/stages/#beta">beta</a>. Please <a href="https://github.com/18F/nsf-sbir/issues/new">report an issue</a>. Visit the <a href="https://www.nsf.gov/eng/iip/sbir/home.jsp">current NSF SBIR/STTR</a> site.</p>
+        <div class="banner-right flex flex-center">
+          <img src="{{ site.baseurl }}/assets/uswds/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government</p>
+        </div>
+        <p class="banner-left">This site is currently in <a href="https://18f.gsa.gov/dashboard/stages/#beta">beta</a>. Please <a href="https://github.com/18F/nsf-sbir/issues/new">report an issue</a>. Visit the <a href="https://www.nsf.gov/eng/iip/sbir/home.jsp">current NSF SBIR/STTR</a> site.</p>
       </div>
     </header>
   </div>

--- a/_sass/flexbox.scss
+++ b/_sass/flexbox.scss
@@ -1,7 +1,11 @@
-.flex {
-  display: flex;
-}
+.flex { display: flex; }
 
-.flex-center {
-  align-items: center;
+.flex-center { align-items: center; }
+
+.flex-column { flex-direction: column; }
+
+.flex-row-md {
+  @include media($small-screen) {
+    flex-direction: row;
+  }
 }

--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -1,10 +1,39 @@
+.usa-banner,
 .usa-banner-header {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.usa-banner-inner {
+  display: flex;
+  justify-content: center;
+
+  @include media($large-screen) {
+    display: block;
+  }
+}
+
+.usa-banner-header {
+
   .usa-label {
     font-size: inherit;
   }
 
+  .banner-left {
+    display: none;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
   .banner-right {
     float: right;
+    margin-bottom: 0;
+    margin-top: 0;
+
+    > * {
+      margin-bottom: 0;
+      margin-top: 0;
+    }
   }
 
   a {
@@ -12,8 +41,10 @@
     text-decoration: underline;
   }
 
-  img {
-    margin-top: 0;
+  @include media($large-screen) {
+    .banner-left {
+      display: inline-block;
+    }
   }
 }
 

--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -20,7 +20,6 @@
   }
 
   .banner-left {
-    display: none;
     margin-bottom: 0;
     margin-top: 0;
   }
@@ -39,12 +38,6 @@
   a {
     border-bottom: 0;
     text-decoration: underline;
-  }
-
-  @include media($large-screen) {
-    .banner-left {
-      display: inline-block;
-    }
   }
 }
 


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/banner-cleanup.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/banner-cleanup)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/banner-cleanup/)

Changes proposed in this pull request:
- Cleaned up banner centering
- Removed left side in mobile and centered the text
- **NOTE**: If reviewing, check out both mobile and larger screens