### PR TITLE
Added PD bio link on Portfolio page

### DIFF
--- a/_includes/tech-subtopics.html
+++ b/_includes/tech-subtopics.html
@@ -16,11 +16,21 @@
     <div class="usa-width-one-fourth">
       <h3 class="subhead">Program director</h3>
       {% for programDirector in topic.programDirector %}
-        <p class="button-arrow">
-          <a href="mailto:{{ programDirector.email }}">
-            {{ programDirector.name }}
-          </a>
+        <p>
+          {{ programDirector.name }}
         </p>
+        <ul>
+          <li>
+            <a href="mailto:{{ programDirector.email }}">
+              Send email
+            </a>
+          </li>
+          <li>
+            <a href="{{ site.baseurl }}/contact/bios#{{ programDirector.name }}">
+              View bio
+            </a>
+          </li>
+        </ul>
       {% endfor %}
     </div>
     <div class="usa-width-three-fourths">

--- a/_sass/portfolio.scss
+++ b/_sass/portfolio.scss
@@ -32,8 +32,11 @@ li:last-child {
 }
 
 .featured-companies {
+  margin-bottom: $space-m;
+
   li {
     padding: 0 $space-m 0 0;
+    line-height: $leading-xs;
   }
 
   a {
@@ -43,7 +46,7 @@ li:last-child {
     display: block;
     font-size: $font-size-xxs;
     font-weight: 700;
-    min-height: 4rem;
+    min-height: $space-xl - $space-s;
     padding-top: $space-xs;
 
     &:hover {
@@ -70,54 +73,79 @@ li:last-child {
     }
   }
 }
+.page-portfolio {
 
-h3.subhead {
-  margin-bottom: $space-m;
-}
+  h2.subhead,
+  h3.subhead {
+    margin-bottom: $space-m;
+    letter-spacing: $kern-loose;
+    color: $color-gray-dark;
+  }
 
-.section-tech-topic {
-  clear: both;
- .tech-topic-title {
-   margin-bottom: $space-xl;
- }
-}
+  .awards-search-form {
+    margin-bottom: $space-xl;
+  }
 
-h2.text-medium.tech-topic-title {
-  font-size: 1.6rem;
-  font-weight: 600;
-}
+  .section-tech-topic {
+    clear: both;
 
-.section-tech-topic .usa-width-one-fourth {
-  margin-bottom: $space-xl;
-}
+    .usa-width-one-fourth {
+      margin-bottom: $space-xl;
 
-#search label {
-  display: block;
-  font-family: $font-serif;
-  font-size: $font-size-xxxs;
-  font-weight: 600;
-  line-height: 1.625;
-  padding: 0;
-  margin: 0;
-}
-#search input.form-control {
-  border: none;
-  border-bottom: 2px solid $color-primary-alt-dark;
-  background-color: $color-neutral-light;
-  color: $color-base;
-  font-family: $font-serif;
-  font-size: $font-size-xs;
-  line-height: 1.625;
-  margin-left: -32px;
-  padding-top: 5px;
-  padding-bottom: 5px;
-  padding-left: 32px;
-  width: 300px;
-}
-#search .btn.btn-default {
-  @include search-icon;
-  background-color: $color-neutral-light;
-  border: none;
-  color: $color-primary-alt-dark;
-  line-height: 1.625;
+      p {
+        margin-bottom: $space-xs;
+        font-size: $font-size-xs;
+        font-weight: 600;
+      }
+      ul {
+        margin: 0;
+        padding: 0;
+        li {
+          margin: 0 0 $space-xs 1.4rem;
+          font-size: $font-size-xxs;
+          list-style-type: circle;
+        }
+      }
+    }
+
+  }
+
+  h2.text-medium.tech-topic-title {
+    font-size: $font-size-m;
+    font-weight: 600;
+    margin-bottom: $space-xl;
+    margin-top: $space-xl;
+  }
+
+  #search label {
+    display: block;
+    font-family: $font-serif;
+    font-size: $font-size-xxxs;
+    font-weight: 600;
+    line-height: $leading-m;
+    padding: 0;
+    margin: 0;
+  }
+  #search input.form-control {
+    border: none;
+    border-bottom: 2px solid $color-primary-alt-dark;
+    background-color: $color-neutral-light;
+    color: $color-base;
+    font-family: $font-serif;
+    font-size: $font-size-xs;
+    line-height: 1.625;
+    margin-left: -32px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 32px;
+    width: 300px;
+  }
+  #search .btn.btn-default {
+    @include search-icon;
+    background-color: $color-neutral-light;
+    border: none;
+    color: $color-primary-alt-dark;
+    line-height: 1.625;
+  }
+
 }

--- a/_sass/portfolio.scss
+++ b/_sass/portfolio.scss
@@ -45,13 +45,11 @@ li:last-child {
   a {
     border-bottom: 0;
     border-top: 1px dotted $color-primary-darkest;
-    // color: $color-primary-darker;
-    // color: $color-primary-darkest;
     color: $color-primary;
     display: block;
     font-size: $font-size-xxs;
-    font-weight: 500;
-    min-height: $space-xl - $space-s;
+    font-weight: 600;
+    min-height: $space-xl - $space-m;
     padding-top: $space-xs;
 
     &:hover {
@@ -84,8 +82,7 @@ li:last-child {
   h3.subhead {
     margin-bottom: $space-m;
     letter-spacing: $kern-loose;
-    // color: $color-gray-dark;
-    color: $color-gray-medium-warm;
+    color: $color-gray-dark;
     font-weight: 400;
   }
 
@@ -119,9 +116,9 @@ li:last-child {
   }
 
   h2.text-medium.tech-topic-title {
-    font-size: $font-size-m;
+    font-size: $font-size-s;
     font-weight: 600;
-    margin-bottom: $space-xl + $space-s;
+    margin-bottom: $space-xl;
     margin-top: $space-xl;
   }
 

--- a/_sass/portfolio.scss
+++ b/_sass/portfolio.scss
@@ -5,6 +5,8 @@
   .tech-subtopics-header {
     display: inline;
     font-size: $font-size-xxs;
+    font-weight: 500;
+    letter-spacing: normal;
   }
   ul {
     display: inline;
@@ -19,6 +21,7 @@ li:last-child {
   li {
     display: inline;
     font-size: $font-size-xxs;
+    color: $color-gray-dark;
 
     &::after {
       background-color: $color-gray-light;
@@ -42,10 +45,12 @@ li:last-child {
   a {
     border-bottom: 0;
     border-top: 1px dotted $color-primary-darkest;
-    color: $color-primary-darkest;
+    // color: $color-primary-darker;
+    // color: $color-primary-darkest;
+    color: $color-primary;
     display: block;
     font-size: $font-size-xxs;
-    font-weight: 700;
+    font-weight: 500;
     min-height: $space-xl - $space-s;
     padding-top: $space-xs;
 
@@ -79,7 +84,9 @@ li:last-child {
   h3.subhead {
     margin-bottom: $space-m;
     letter-spacing: $kern-loose;
-    color: $color-gray-dark;
+    // color: $color-gray-dark;
+    color: $color-gray-medium-warm;
+    font-weight: 400;
   }
 
   .awards-search-form {
@@ -95,6 +102,7 @@ li:last-child {
       p {
         margin-bottom: $space-xs;
         font-size: $font-size-xs;
+        letter-spacing: $kern-tight;
         font-weight: 600;
       }
       ul {
@@ -113,39 +121,9 @@ li:last-child {
   h2.text-medium.tech-topic-title {
     font-size: $font-size-m;
     font-weight: 600;
-    margin-bottom: $space-xl;
+    margin-bottom: $space-xl + $space-s;
     margin-top: $space-xl;
   }
 
-  #search label {
-    display: block;
-    font-family: $font-serif;
-    font-size: $font-size-xxxs;
-    font-weight: 600;
-    line-height: $leading-m;
-    padding: 0;
-    margin: 0;
-  }
-  #search input.form-control {
-    border: none;
-    border-bottom: 2px solid $color-primary-alt-dark;
-    background-color: $color-neutral-light;
-    color: $color-base;
-    font-family: $font-serif;
-    font-size: $font-size-xs;
-    line-height: 1.625;
-    margin-left: -32px;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    padding-left: 32px;
-    width: 300px;
-  }
-  #search .btn.btn-default {
-    @include search-icon;
-    background-color: $color-neutral-light;
-    border: none;
-    color: $color-primary-alt-dark;
-    line-height: 1.625;
-  }
 
 }

--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -12,7 +12,6 @@
   padding-left: 4rem;
   }
   label {
-    font-weight: $font-bold;
-    margin-top: 0;
+    margin-top: $space-xs;
   }
 }

--- a/_sass/uswds-overrides.scss
+++ b/_sass/uswds-overrides.scss
@@ -34,7 +34,6 @@ ol {
 }
 
 
-
 .usa-grid-center {
   &:last-child {
     float: none;

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -68,6 +68,7 @@ $leading-xxs: 1.2;
 // Letter-spacing
 $kern-tight: -.015em;
 $kern-loose: .0625em;
+$kern-looser: .0825em;
 
 // Spacing
 $space-xs: .5rem;

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -1,10 +1,13 @@
 
 // Color USWDS Overrides
-$color-primary: #0071BC;
-$color-primary-darkest: #112E51;
-$color-primary-darker: #205493;
+$color-primary: #002277; // formerly #0071BC;
+$color-primary-darkest: #003366; // formerly #112E51;
+$color-primary-darker: #005588; // formerly #205493;
+$color-visited: #406098;  // new color
 
 $color-gray-dark: #323A45;
+$color-gray-medium-warm: #696969;
+$color-gray-medium-cool: #4F5A65;
 $color-gray-light: #AEB0B5;
 
 $color-primary-alt: #02BFE7;
@@ -36,11 +39,13 @@ $color-tertiary-light: #E59393;
 $color-tertiary-lightest: #F9DEDE;
 $color-white-transprent: rgba(255,255,255,.9);
 
+
 // Backgrounds
 $color-bg-light: #F5FBFC;
 
 $bg-color: #F7F7F7;
 $hero-bg-color: #AAAAAA;
+$visited: #406098;
 // End Unique colors
 
 // Typography

--- a/pages/portfolio.md
+++ b/pages/portfolio.md
@@ -16,12 +16,6 @@ section_image_caption: |
 # Portfolio
 Since 2012, America’s Seed Fund powered by NSF has made nearly 2,500 awards to startups and small businesses. Since 2010, our awardees have had 62 exits and have received $3.2 billion in private investment. We encourage you to explore this list of assorted companies we've funded.
 
-<p class="text-medium" markdown="1">
-
-
-
-</p>
-
 
 <form onsubmit="allAwards(this.a1.value); return false;" class="awards-search-form">
  {% comment %}
@@ -49,9 +43,12 @@ Since 2012, America’s Seed Fund powered by NSF has made nearly 2,500 awards to
 
 <section class="background-light-neutral" markdown="1">
 <div class="usa-section-tight-top usa-section usa-content usa-grid" markdown="1">
+
 **View our current awardees,** who are still completing the research outlined in their proposals and who haven't yet reached the estimated ends of their award terms. [View current Phase I awardees]({{ site.baseurl }}/awardees/phase-1/), [Current Phase II awardees]({{ site.baseurl }}/awardees/phase-2/), or our [most recent ({{ recent_date }}) Phase I awardees]({{ site.baseurl }}/awardees/phase-1-recent/).
+
 </div>
 </section>
+
 <section class="section-background-image">
   <div class="usa-grid">
     <div class="usa-width-one-third">
@@ -59,6 +56,7 @@ Since 2012, America’s Seed Fund powered by NSF has made nearly 2,500 awards to
     </div>
   </div>
 </section>
+
 <section class="background-light-neutral">
 <div class="usa-section usa-content usa-grid">
 <h2 class="text-large">We fund varied tech sectors.</h2>
@@ -67,22 +65,3 @@ Since 2012, America’s Seed Fund powered by NSF has made nearly 2,500 awards to
 {% include tech-subtopics.html %}
 </div>
 </section>
-
-
-
-{% comment %}
-## Awardees pages
-
-Our current awardees pages feature information about Phase I and Phase II awardees who are actively using their funding. Recent awardees pages highlight companies that received funding during the previous solicitation period.
-
-### Current awardees / Phase I
-
-Phase 1 funding (up to $225,000 over 6-12 months) covers R&D, including exploration of product-market fit, prototyping, and planning to scale your technology.
-
-### Current awardees / Phase II
-
-Phase II funding (up to an additional $750,000 over two years) helps you continue the research you started in Phase I.
-
-### Recent awardees
-Recent awardees received funding during the last solicitation period, which closed in (December 2016). These awards were announced in (February 2016).
-{% endcomment %}


### PR DESCRIPTION
Added link to PD bio from the Portfolio page. (The original intent was for the PD to link their bio but, because we didn't have bios earlier, we linked to their email instead.)

Also includes some design debt tweaks:
- Adjusted colors so link colors are a little sharper and replaced the off-palette violet (inherited from USWDS) for visited links
- removed portfolio styles (used for placeholder search) that were no longer needed

[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/folio.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/folio)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/folio/portfolio/)


/cc @kmonterr @line47 
