### PR TITLE
Using variables for solicitation links

### DIFF
--- a/_timeline/step-2.md
+++ b/_timeline/step-2.md
@@ -3,7 +3,7 @@ title: Review the solicitation
 becomes_inactive: true
 description: Read the solicitation, which includes everything you need to know about applying for funding.
 inactive_description: |
-  We're not currently accepting proposal applications, but you can check out our most recent [SBIR solicitation](https://www.nsf.gov/pubs/2017/nsf17544/nsf17544.htm) and [STTR solicitation](https://www.nsf.gov/pubs/2017/nsf17545/nsf17545.htm). Our next solicitation will be released in {{ site.deadline }}
+  We're not currently accepting proposal applications, but you can check out our most recent [{{ site.data.solicitations['SBIR'].title }}]({{ site.data.solicitations['SBIR'].url }}) and [{{ site.data.solicitations['STTR'].title }}]({{ site.data.solicitations['STTR'].url }}). Our next solicitation will be released in {{ site.deadline }}
 ---
 
 The solicitation has information on awards (number available and award amounts), tips for preparing your proposal, and more.


### PR DESCRIPTION
Updating the site to use variables for links to the SBIR and STTR solicitations.

