### PR TITLE
Adding a period

### DIFF
--- a/_timeline/step-2.md
+++ b/_timeline/step-2.md
@@ -3,7 +3,7 @@ title: Review the solicitation
 becomes_inactive: true
 description: Read the solicitation, which includes everything you need to know about applying for funding.
 inactive_description: |
-  We're not currently accepting proposal applications, but you can check out our most recent [{{ site.data.solicitations['SBIR'].title }}]({{ site.data.solicitations['SBIR'].url }}) and [{{ site.data.solicitations['STTR'].title }}]({{ site.data.solicitations['STTR'].url }}). Our next solicitation will be released in {{ site.deadline }}
+  We're not currently accepting proposal applications, but you can check out our most recent [{{ site.data.solicitations['SBIR'].title }}]({{ site.data.solicitations['SBIR'].url }}) and [{{ site.data.solicitations['STTR'].title }}]({{ site.data.solicitations['STTR'].url }}). Our next solicitation will be released in {{ site.deadline }}.
 ---
 
 The solicitation has information on awards (number available and award amounts), tips for preparing your proposal, and more.


### PR DESCRIPTION
Last sentence in inactive-state description needed a period.

Fixes issue(s) # (not a specific issue)

[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/copyedits.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/copyedits)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/copyedits/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/copyedits/README.md)

Changes proposed in this pull request:
- Adding a period to the last sentence of the inactive description.
-
-

/cc @relevant-people
