### PR TITLE
Search for broken links on the site

### DIFF
--- a/_includes/program-directors.html
+++ b/_includes/program-directors.html
@@ -5,7 +5,7 @@
         <img src="{{ site.baseurl }}/assets/img/pd/{{ director.photo }}" alt="{{ director.name }} headshot">
       {% endif %}
       <span class="pd-list-content">
-        <h3 class="pd-name"><a href="{{ site.baseurl }}/contact/bios#{{ director.name }}">{{ director.name }}</a></h3>
+        <h3 class="pd-name"><a href="{{ site.baseurl }}/contact/bios/#{{ director.name }}">{{ director.name }}</a></h3>
         {% if director.topics.size > 0 %}
           <ul class="pd-topic-list">
             {% for topic in director.topics %}

--- a/_includes/tech-subtopics.html
+++ b/_includes/tech-subtopics.html
@@ -28,7 +28,7 @@
             </a>
           </li>
           <li>
-            <a href="{{ site.baseurl }}/contact/bios#{{ programDirector.name }}">
+            <a href="{{ site.baseurl }}/contact/bios/#{{ programDirector.name }}">
               View bio
             </a>
           </li>

--- a/pages/about.md
+++ b/pages/about.md
@@ -4,7 +4,7 @@ permalink: /about/
 layout: secondary
 section_image: "/assets/img/bg/robotic-arm.jpg"
 section_image_caption: |
-  The first robotic printer used by [Branch Technology](#) in late 2014 to develop the initial proof of concept for CFAB® prior to SBIR Phase I research.
+  The first robotic printer used by [Branch Technology]({{ site.baseurl }}/portfolio/details/?company=branch-technology-llc) in late 2014 to develop the initial proof of concept for CFAB® prior to SBIR Phase I research.
 ---
 <section class="section-header background-light-blue">
 <div class="usa-section usa-content usa-grid">


### PR DESCRIPTION
I couldn't get `htmlproofer` working (I actually discovered a bug showing that `18f.gsa.gov` isn't properly using it), so I scanned several of the key pages with my chrome extension and found a few broken links

 [![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/check-links.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/check-links)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/check-links/)