### PR TITLE
styled expired label; adjusted gray contrast for accessibility

### DIFF
--- a/_sass/timeline.scss
+++ b/_sass/timeline.scss
@@ -91,6 +91,17 @@ $timeline-right-padding: 5rem;
         border-color: $color-gray-lightest;
         color: $color-gray-light;
       }
+      .step-label-expired {
+        font-family: $font-mono;
+        font-size: $font-size-xxxs;
+        font-weight: 400;
+        color: $color-gray-medium-warm;
+        text-transform: uppercase;
+        letter-spacing: $kern-looser;
+        background-color: $color-secondary-lightest;
+        padding: 1px 4px;
+        margin-left: $space-xxs;
+      }
     }
 
     // setup accordion arrow
@@ -143,7 +154,9 @@ $timeline-right-padding: 5rem;
     button[disabled] {
     background-color: $color-white;
     background-image: none;
-    color: $color-gray-light;
+    // color: $color-gray-light;
+    color: $color-gray-medium-warm;
+    font-weight: 500;
     }
   }
 


### PR DESCRIPTION
Fixes issue(s) #645 .

[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/expired-iss645/apply/)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/expired-iss645/apply/)

Changes proposed in this pull request:
- styled `expired` label so it's visually separated from the section heading
- fixed low contrast gray headings for the disabled sections

/cc @line47 @kmonterr 
