### PR TITLE
Minor wording change to Apply timeline step

### DIFF
--- a/_timeline/step-4.md
+++ b/_timeline/step-4.md
@@ -3,7 +3,7 @@ title: Review the solicitation
 becomes_inactive: true
 description: Read the solicitation, which includes everything you need to know about applying for funding.
 inactive_description: |
-  We're not currently accepting proposal applications, but you can check out our most recent [{{ site.data.solicitations['SBIR'].title }}]({{ site.data.solicitations['SBIR'].url }}) and [{{ site.data.solicitations['STTR'].title }}]({{ site.data.solicitations['STTR'].url }}). Our next solicitation will be released in {{ site.deadline }}.
+  We're not currently accepting proposal applications, but you can check out our most recent [{{ site.data.solicitations['SBIR'].title }}]({{ site.data.solicitations['SBIR'].url }}) or [{{ site.data.solicitations['STTR'].title }}]({{ site.data.solicitations['STTR'].url }}) to get a sense of what they cover. Our next solicitation will be released in {{ site.deadline }}.
 ---
  
 The solicitation has information on awards (number available and award amounts), tips for preparing your proposal, and more.


### PR DESCRIPTION
Per issue #580, tweaking the wording a bit.

Fixes issue(s) #580 

@line47 - right now, the solicitation release date is `site deadline` - does this reflect the (deadline month - three months)? (The issue with the current step is that it lists Dec. 2017 as the next upcoming release, when it should be Sept. 2017.) I wasn't sure how to update this, but I wanted to bring it to your attention - let me know if you have any questions. 

[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/apply-changes.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/apply-changes)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/apply-changes/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/apply-changes/README.md)

Changes proposed in this pull request:
- Changing the wording slightly 
-
-

/cc @line47 
