### PR TITLE
Transferring applicant info to For applicants page

### DIFF
--- a/pages/for-applicants.md
+++ b/pages/for-applicants.md
@@ -4,6 +4,29 @@ layout: secondary-narrow
 permalink: /resources/applicants/ 
 ---
 
-# For Applicants
+# For applicants
 
-If you’re interested in applying, we recommend watching our videos, joining us at an event or reaching out directly to our program directors to learn more about the program and what we hope to see in your proposal.
+If you’re interested in applying for funding, we encourage you to watch our videos, join us at an event, or reach out directly to our program directors to learn more about the program and what we hope to see in your proposal.
+
+{% if site.app_process == "active" %}
+## Q&A webinars
+
+Thinking of applying for Phase I funding? Ask all your application-related questions during our Q&A webinars. Can’t make it to a webinar? Check out our videos covering [program basics](https://www.youtube.com/watch?v=1Tm_ToVRpqE) and [what you need to know before applying](https://www.youtube.com/watch?v=-0lhmfczIJ8&feature=youtu.be). (We offer a [PDF version of program basics](https://www.nsf.gov/eng/iip/sbir/documents/About_NSF_SBIR_STTR.pdf), too.)
+
+{% else %}
+## Q&A videos
+
+Thinking of applying for Phase I funding? Check out our videos covering [program basics](https://www.youtube.com/watch?v=1Tm_ToVRpqE) and [what you need to know before applying](https://www.youtube.com/watch?v=-0lhmfczIJ8&feature=youtu.be). (We offer a [PDF version of program basics](https://www.nsf.gov/eng/iip/sbir/documents/About_NSF_SBIR_STTR.pdf), too.) 
+{% endif %}
+
+## Startup and partnership profiles
+
+Get to know our awardees better — we’ve got [video profiles of funded startups and small businesses](https://www.youtube.com/playlist?list=PLGhBP1C7iCOkPp8yv2I3ZGk16LiMIiikb), along with [profiles of funded startup partnerships](https://www.youtube.com/playlist?list=PLGhBP1C7iCOkmWtgG1BKTZpfMMCDkYY61).
+
+## FastLane guide
+
+Before you start your application, take a look at our [FastLane guide]({{ site.baseurl }}/fastlane/fastlane-1/). This way, once the next solicitation opens, you'll be ready to craft your application. 
+
+## FAQ
+
+Have lingering questions? Visit our [FAQ](https://www.nsf.gov/pubs/2017/nsf17071/nsf17071.jsp), which covers the pre-application process to post-award reporting (and everything in between).


### PR DESCRIPTION
Transferring applicant-related info from `Resources` to `For applicants`

Fixes issue(s) #653 

[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/applicanttransfer.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/applicanttransfer)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/applicanttransfer/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/applicanttransfer/README.md)

Changes proposed in this pull request:
-Transferring applicant-related info from `Resources` to `For applicants`
-
-

/cc @line47 and @kmonterr 
