### PR TITLE
Fix details page error logic

### DIFF
--- a/_includes/company.html
+++ b/_includes/company.html
@@ -9,11 +9,9 @@
   {% assign company_name = company_name | append: " (formerly " | append: company['past'] | append: ")" %}
   {% if awardee_slug == company_past_slug %}
     <li><a href="{{ site.baseurl }}/portfolio/details/?company={{ company_past_slug }}">{{ company_name }}</a></li>
-    {% if include.iterator %}{% assign iterator = iterator | plus: 1 %}{% endif %}
     {% break %}
   {% elsif awardee_slug == company_slug %}
     <li><a href="{{ site.baseurl }}/portfolio/details/?company={{ company_slug }}">{{ company_name }}</a></li>
-    {% if include.iterator %}{% assign iterator = iterator | plus: 1 %}{% endif %}
     {% break %}
   {% endif %}
 {% elsif company['dba'] %}
@@ -21,17 +19,14 @@
   {% assign company_name = company_name | append: " (dba " | append: company['dba'] | append: ")" %}
   {% if awardee_slug == company_dba_slug %}
     <li><a href="{{ site.baseurl }}/portfolio/details/?company={{ company_dba_slug }}">{{ company_name }}</a></li>
-    {% if include.iterator %}{% assign iterator = iterator | plus: 1 %}{% endif %}
     {% break %}
   {% elsif awardee_slug == company_slug %}
     <li><a href="{{ site.baseurl }}/portfolio/details/?company={{ company_slug }}">{{ company_name }}</a></li>
-    {% if include.iterator %}{% assign iterator = iterator | plus: 1 %}{% endif %}
     {% break %}
   {% endif %}
 {% else %}
   {% if awardee_slug == company_slug %}
     <li><a href="{{ site.baseurl }}/portfolio/details/?company={{ company_slug }}">{{ company_name }}</a></li>
-    {% if include.iterator %}{% assign iterator = iterator | plus: 1 %}{% endif %}
     {% break %}
   {% endif %}
 {% endif %}

--- a/_includes/featured-companies.html
+++ b/_includes/featured-companies.html
@@ -1,9 +1,9 @@
-{% assign max_companies_shown_limit = site['topics_api']['max_companies_shown'] | plus: 1 %}
+{% assign max_companies_shown_limit = site['topics_api']['max_companies_shown'] %}
 
 <ul class="flex-list flex-list-4-col featured-companies shuffled-list">
 
-{% assign shuffled_featured_companies = site.data.featured-companies | shuffle %}
-{% for company in shuffled_featured_companies limit: max_companies_shown_limit %}
+{% assign shuffled_featured_companies = site.data.featured-companies | sample: max_companies_shown_limit %}
+{% for company in shuffled_featured_companies %}
   {% for topic in site.data.topics %}
     {% assign awardee_name = topic['awardeeName'] %}
     {% include company.html company=company awardee_name=awardee_name %}

--- a/_includes/tech-subtopics.html
+++ b/_includes/tech-subtopics.html
@@ -40,12 +40,11 @@
         <h3 class="subhead">Featured companies</h3>
         <ul class="flex-list flex-list-3-col featured-companies shuffled-list">
           {% assign iterator = 0 %}
-          {% assign shuffled_companies = topic.companies | shuffle %}
+          {% assign shuffled_companies = topic.companies | sample: max_companies_shown %}
           {% for company in shuffled_companies %}
-            {% if iterator == max_companies_shown %}{% break %}{% endif %}
             {% for t in site.data.topics %}
               {% assign awardee_name = t['awardeeName'] %}
-              {% include company.html company=company awardee_name=awardee_name iterator='true' %}
+              {% include company.html company=company awardee_name=awardee_name %}
             {% endfor %}
           {% endfor %}
         </ul>

--- a/_layouts/awardees.html
+++ b/_layouts/awardees.html
@@ -85,7 +85,7 @@ class: awardees-layout
                 <li class="table-row">
                   <div class="table-row-item" data-header="Company">
                     {% assign awardeeSlug = matching.awardeeName | slugify %}
-                    <a href="{{ page.details_url | append: awardeeSlug | append: '#' | append: awardeeSlug | relative_url }}" alt="{{ matching.awardeeName }}">
+                    <a href="{{ page.details_url | append: awardeeSlug | relative_url }}" alt="{{ matching.awardeeName }}">
                     <span>{{ matching.awardeeName }}</span>
                     </a>
                   </div>

--- a/_plugins/utility.rb
+++ b/_plugins/utility.rb
@@ -40,10 +40,6 @@ module Jekyll
       end
     end
 
-    def shuffle(array)
-      array.shuffle
-    end
-
     def matches_url(page_url, url)
       if url.is_a? Array
         urls = url.map do |u|

--- a/assets/js/awardees-static.js
+++ b/assets/js/awardees-static.js
@@ -77,14 +77,15 @@ $(function() {
 
   function showFailure(text) {
     var text = text || getQueryVariable('company');
-    var visibleAwards = awardsLists.map(function(list) { return list.visibleItems.length == 0 })
-    if (visibleAwards.indexOf(true) < 0) {
+    var visibleAwards = awardsLists.map(function(list) { return list.visibleItems.length > 0; })
+
+    if (visibleAwards.indexOf(true) >= 0) {
+      $('.results-failure').hide();
+      $('.awards-search-form').hide();
+    } else {
       $('.results-query').text(text);
       $('.results-failure').show();
       $('.awards-search-form').show();
-    } else {
-      $('.results-failure').hide();
-      $('.awards-search-form').hide();
     }
   }
 


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/nsf-sbir/tree/fix-error-logic.svg?style=svg)](https://circleci.com/gh/18F/nsf-sbir/tree/fix-error-logic)

Preview: https://federalist-proxy.app.cloud.gov/preview/18f/nsf-sbir/fix-error-logic/portfolio/

Changes proposed in this pull request:
- This fixes the issue that we were seeing on the portfolio and awardees details pages showing that an award was not found
- replaces `shuffle` method with `sample` for elegance

