### PR TITLE
Change email text and address in "Errata" section of details page

### DIFF
--- a/_includes/details-listing.html
+++ b/_includes/details-listing.html
@@ -64,7 +64,7 @@
       </div>
       <div class="mb5">
         <h4 class="subhead uppercase">Errata</h4>
-        <p class="abstractText">Please report errors in award information by writing to <a href="mailto:awardsearch.nsf.gov">awardsearch.nsf.gov</a>.</p>
+        <p class="abstractText">Please report errors in award information by writing to <a href="mailto:awardsearch@nsf.gov">awardsearch@nsf.gov</a>.</p>
       </div>
       <div class="mb5">
         <h4 class="subhead uppercase">Addenda</h4>


### PR DESCRIPTION
Addressing issue reported here: https://github.com/18F/nsf-sbir/issues/809

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/errata/)

Changes proposed in this pull request:
- Changes text and address from `awardsearch.nsf.gov` to `awardsearch@nsf.gov`

/cc @femmebot @kmonterr 
