### PR TITLE
Update awardees.md

### DIFF
--- a/pages/resources/awardees/phase-2/awardees.md
+++ b/pages/resources/awardees/phase-2/awardees.md
@@ -18,8 +18,8 @@ Here are all the forms you need to manage your Phase II award.
 - [Change of PI (principal investigator)]({{ site.baseurl }}/resources/awardees/phase-2/pi-change/)  
 
 ## Additional awardee information
-- [Supplemental funding opportunities: Phase II]({{ site.baseurl }}/resources/awardees/phase-2/supplement/)
-- Learn how to apply for [supplemental funding opportunities]({{ site.baseurl }}/resources/awardees/supplement/overview/)
+- [Supplemental funding opportunities: Phase II]({{ site.baseurl }}/resources/awardees/supplement/overview/)
+- Learn how to apply for [supplemental funding opportunities]({{ site.baseurl }}/resources/awardees/phase-2/instructions/)
 - Learn about [Phase II general award conditions](https://www.nsf.gov/awards/managing/special_conditions.jsp)
 
 ## Spreading the word


### PR DESCRIPTION
Two of the links were driving to the wrong pages. I think they should work, but want to check before merging, since we just moved the overall fastlane supplement instructions page and changed the link!

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/P2 awardees links/)

Changes proposed in this pull request:
-Supplemental funding opportunities: Phase II - changed link to go to the overview page
-Learn how to apply for supplemental funding opportunities - changed to go to the overall fastlane instructions page

/cc @relevant-people
