### PR TITLE
Fixing the Footer

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -127,10 +127,10 @@ footer:
     href: /portfolio/
   - text: Apply for funding
     href: /apply/
-  - text: Resources
-    href: /resources/
-  - text: Events
-    href: /events/
+  - text: Showcase
+    href: /showcase/
+  - text: For Press
+    href: /press/
   - text: Contact us
     href: /contact/
 
@@ -145,5 +145,5 @@ subfooter:
     href: https://www.nsf.gov/about/
   - text: Inspector General
     href: https://www.nsf.gov/oig/
-  - text: For Press
-    href: /press/
+  - text: SBIR.gov
+    href: https://www.sbir.gov/


### PR DESCRIPTION
Removed "Resources" because it was a deadlink. 
Added Showcase instead
Added SBIR.gov
Moved For Press up

Fixes issue(s) #711 and others.

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/footer fixes/)

it's my first real time making changes to the footer without you, @line47. Double checking that I did it right!
