### PR TITLE
Updating url for portfolio search

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -89,6 +89,6 @@ function currentAwards(a1) {
 window.open('https://www.nsf.gov/awardsearch/advancedSearchResult?PIId=&PIFirstName=&PILastName=&PIOrganization=&PIState=&PIZip=&PICountry=&ProgOrganization=&ProgEleCode=5373%2C+1591%2C+5371%2C+1505&BooleanElement=Any&ProgRefCode=&BooleanRef=All&Program=&ProgOfficer=&Keyword=' + a1 + '&AwardNumberOperator=&AwardAmount=&AwardInstrument=&ActiveAwards=true&OriginalAwardDateOperator=&StartDateOperator=&ExpDateOperator=',   'a1window');
 }
 function allAwards(a1) {
-window.open('https://www.nsf.gov/awardsearch/advancedSearchResult?PIId=&PIFirstName=&PILastName=&PIOrganization=&PIState=&PIZip=&PICountry=&ProgOrganization=&ProgEleCode=5373%2C+1591%2C+5371%2C+1505&BooleanElement=Any&ProgRefCode=&BooleanRef=All&Program=&ProgOfficer=&Keyword=' + a1 + '&AwardNumberOperator=&AwardAmount=&AwardInstrument=&ActiveAwards=true&OriginalAwardDateOperator=&StartDateOperator=&ExpDateOperator=',   'a1window');
+window.open('https://www.nsf.gov/awardsearch/simpleSearchResult?queryText=' + a1 + '&ActiveAwards=true',   'a1window');
 }
 </script>


### PR DESCRIPTION
Fixes issue(s) https://github.com/18F/nsf-sbir/issues/824

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/porfolio-search/)

Changes proposed in this pull request:
- Updating the URL to make the portfolio search use the NSF simple search as opposed to the advanced search

