### PR TITLE
Ea topic

### DIFF
--- a/_data/tech-topics.yml
+++ b/_data/tech-topics.yml
@@ -4,6 +4,7 @@
   programDirector:
     - name: Rajesh Mehta
       last_name: Mehta
+      api_name: Rajesh Mehta
       email: rmehta@nsf.gov
       photo: Rajesh-compressed.jpg
       bio: "is a Program Director in the Small Business Innovation Research Program at the National Science Foundation. His focus areas include Advanced Manufacturing and Nanotechnology. Prior to joining NSF in 2012, he was a senior research technologist at Kodak where his 26-year career spanned work at Kodak Research Laboratories, and Manufacturing Research and Engineering Organization. His work covered a broad range of materials science based technologies related to photographic film and paper manufacturing, thermal, inkjet, and electro-photographic printing, and OLED device manufacturing. He has a B. Tech. degree in Chemical Engineering from Indian Institute of Technology, Bombay, M.S. and Ph.D. degrees in Chemical Engineering from Penn State, a post-doctoral fellowship at Imperial College, and a M.S. degree in New Product Development from Rochester Institute of Technology."
@@ -43,6 +44,7 @@
   programDirector:
     - name: Debasis Majumdar
       last_name: Majumdar
+      api_name: Debasis Majumdar
       email: dmajumda@nsf.gov
       photo: Debasis-compressed.jpg
       bio: "joined the National Science Foundation as a Program Director in the Industrial Innovation and Partnerships Division of the Engineering Directorate in 2015. Prior to joining NSF, he was a Research Associate at Saint-Gobain and a Senior Principal Scientist at Eastman Kodak Company, spanning an industrial career of over 30 years. In that capacity, he was engaged in applied research, new product development and commercialization, manufacturing excellence, technology transfer and intellectual property development and management. His research expertise includes advanced materials comprising polymers, metals, ceramics, inorganic-organic nanocomposites and functional coatings for a variety of applications such, as imaging, display and life science. He is a co-inventor of more than 100 US patents and a co-author of more than 30 peer reviewed papers and book chapters. Debasis holds a Ph.D. degree in Materials Science and Engineering from Northwestern University and a B.Tech. degree in Metallurgical Engineering from Indian Institute of Technology, Kharagpur."
@@ -104,6 +106,7 @@
   programDirector:
     - name: Henry Ahn
       last_name: Ahn
+      api_name: Henry Ahn
       email: hahn@nsf.gov
       photo: Henry-compressed.jpg
       bio: "joined the National Science Foundation in July 2016 as an SBIR/STTR Program Director. Prior to joining NSF, Henry managed seed/early stage investment programs for TEDCO for 12 years including Technology Commercialization Fund, TEDCO’s flagship seed funding program for technology-based companies in Maryland. During his time at TEDCO, Henry was actively involved with various entrepreneurs and entrepreneur support groups as a guest speaker, an advisory board member, a judge, a mentor, among others. Additionally, Henry was part of the licensing/supplier relations team at a biotechnology company called Upstate, where he successfully negotiated, licensed and commercialized approximately 190 biomedical research reagents from around the world. Henry has also done approximately 5 years of research, mostly in the field of immunology (including graduate work). Henry has an MBA from Rice University, an M.S. in biotechnology from the University of Tennessee, Knoxville and a B.S. in biomedical engineering from Boston University."
@@ -132,6 +135,7 @@
   programDirector:
     - name: Anna Brady-Estevez
       last_name: Brady-Estevez
+      api_name: Anna Brady-Estevez
       email: abrady@nsf.gov
       photo: Anna-compressed.jpg
       bio: "joined the National Science Foundation as SBIR/STTR Program Director leading Chemical and Environmental Technologies. In this role she brings breadth of background across entrepreneurship and venture capital, innovative research, and direction of corporate strategy and investments. Anna has served as a collaborator with numerous start-ups having worked as: an inventor for an early stage venture-backed start-up providing low-cost, low-energy portable water treatment, and a Principal Investor for an early stage venture firm. Anna’s contributions were recognized in 2009 when she was selected as one of ~30 Kauffman Fellows from around the globe, for leadership in innovation and venture capital. She served as Director of Corporate Strategy for leading multinationals including The AES Corporation and Cummins Inc., and advised numerous clients while serving as a management consultant for The Boston Consulting Group. Anna’s work in these roles resulted in over $6B of infrastructure investments with enhanced returns, identification of $B+ cost reduction opportunities, contributing to a core transformation team of a $T+ entity in oil & gas, and the implementation of several new technologies spanning: nanotechnology, advanced manufacturing, Big Data and Internet of Things, along with new equipment that enabled transforming energy economics. Earlier in her career, she performed research at the intersection of innovation and international relations with the Office of Naval Research at the US Embassy in Chile. Anna holds a PhD from Yale University in Chemical and Environmental Engineering, where she held a National Science Foundation Graduate Research Fellowship; and a BS in Chemical Engineering and BA in Spanish from The Johns Hopkins University."
@@ -166,8 +170,9 @@
   permalink: /topics/educational/
   topic_code: ea
   programDirector:
-    - name: Glenn H. Larsen
+    - name: Ben Schrag
       last_name: Schrag
+      api_name: Glenn H. Larsen
       email: bschrag@nsf.gov
       photo: Ben-compressed.jpg
       bio: "is the Senior Program Director for the SBIR/STTR programs. He joined the NSF as a Program Director in 2009, leading the Advanced Materials and Instrumentation portfolio in the Small Business Innovation Research and Small Business Technology Transfer programs. Prior to NSF, he was the Director of Research and Development at Micro Magnetics, where he led a development effort to commercialize a new family of high-performance magnetic microsensor products for demanding consumer and military applications. During this time, he also served as a visiting scientist at Brown University and as the Principal Investigator on a number of federal grants and contracts, including NSF Phase I and Phase II Small Business Innovation Research projects and an Advanced Technology Program award from NIST. Ben received his Ph.D. in Physics from Brown University."
@@ -200,6 +205,7 @@
   programDirector:
     - name: Muralidharan S. Nair
       last_name: Nair
+      api_name: Muralidharan S. Nair
       email: mnair@nsf.gov
       photo: Murali-compressed.jpg
       bio: "is a Program Director in the areas of Electronic Hardware, Robotics, and Wireless Technologies with the SBIR/STTR Program. Prior to joining NSF in January 2003, he was the Founder CEO of a Bluetooth wireless product company. In this capacity, he raised equity capital for worldwide operations in the U.S., China and India. He designed, planned and implemented the product development cycle, and managed the marketing strategy, strategic alliances and business development processes. Before that, he was a Senior Systems Engineer at L-3 Communications where he provided strategic advice to the Executive VP for a complete re-plan of the Hughes contract for real-time, embedded ground control software for the $350M PANAMSAT communications satellite. Prior to joining L-3 Communications, he was a Mission Planner at Motorola Iridium where he was involved in all aspects of satellite operations including orbit determination, generating guidance targets and orbital slot placement. Before joining Iridium, he was a faculty member at Embry-Riddle Aeronautical University, where he developed an entire Space Systems Design Lab from concept inception to fully operational mode and national prominence, and supervised five (5) space system designs, three (3) of which were winners in the National AIAA/Loral Design Competition. He is a recipient of a number of awards including NSF’s second highest award for meritorious service and the President’s Innovation Award for Space Systems Design courses while at Embry-Riddle. Murali is a graduate of the Indian Institute of Technology and the University of Texas. He is a registered professional engineer in the State of Florida."
@@ -238,6 +244,7 @@
   programDirector:
   - name: Peter Atherton
     last_name: Atherton
+    api_name: Peter Atherton
     email: patherto@nsf.gov
     photo: Peter-compressed.jpg
     bio: "comes to the NSF with a broad background in the physical sciences, and extensive experience in technology development and commercialization. Before joining NSF Peter was originally CEO, and most recently CTO, at MIKOH Corporation Ltd, a publicly traded company that he founded in Sydney, Australia. Prior to MIKOH he spent approximately 7 years at the Overseas Telecommunications Commission (OTC Australia) where he managed optical fiber communications R&D, including approximately 14 months in the UK at British Telecom’s Martlesham Heath R&D laboratories. While at OTC his research group made world-leading advances in high-speed optical communications technologies, some of which were commercialized via spin-off companies. He also managed the externally contracted development and commercialization of a number of optical fiber and optoelectronic technologies, and was instrumental in establishing a commercialization center for specialized optical fibers at the University of Sydney. While at MIKOH Corporation he was instrumental in developing and commercializing technologies in a range of fields including diffractive optics, laser-based marking, radio frequency identification and internet-based personal authentication. He moved to the US in 1998 to further develop the company’s technologies and markets. Peter holds a Ph.D. in physics (Quantum Optics), and a BEng (Mech) – both from the University of Queensland (Australia)."
@@ -354,6 +361,7 @@
   programDirector:
     - name: Ben Schrag
       last_name: Schrag
+      api_name: Ben Schrag
       email: bschrag@nsf.gov
       photo: Ben-compressed.jpg
       bio: "is the Senior Program Director for the SBIR/STTR programs. He joined the NSF as a Program Director in 2009, leading the Advanced Materials and Instrumentation portfolio in the Small Business Innovation Research and Small Business Technology Transfer programs. Prior to NSF, he was the Director of Research and Development at Micro Magnetics, where he led a development effort to commercialize a new family of high-performance magnetic microsensor products for demanding consumer and military applications. During this time, he also served as a visiting scientist at Brown University and as the Principal Investigator on a number of federal grants and contracts, including NSF Phase I and Phase II Small Business Innovation Research projects and an Advanced Technology Program award from NIST. Ben received his Ph.D. in Physics from Brown University."

--- a/_data/tech-topics.yml
+++ b/_data/tech-topics.yml
@@ -166,7 +166,7 @@
   permalink: /topics/educational/
   topic_code: ea
   programDirector:
-    - name: Ben Schrag
+    - name: Glenn H. Larsen
       last_name: Schrag
       email: bschrag@nsf.gov
       photo: Ben-compressed.jpg

--- a/_layouts/awardees.html
+++ b/_layouts/awardees.html
@@ -63,7 +63,7 @@ class: awardees-layout
   <div class="usa-grid">
     <div class="usa-accordion awardees-details-accordion">
     {% for topic in site.data.tech-topics %}
-      {% assign po_name = topic.programDirector[0].api_name | default: topic.programDirector[0].name %}
+      {% assign po_name = topic.programDirector[0].api_name | default: topic.programDirector[0].last_name %}
       {% assign matching_awards = site.data[page.dataset] | uniq | where:'poName', po_name | sort_insensitive:'awardeeName' %}
       {% if matching_awards.size > 0 %}
         <div class="border-bottom">

--- a/_layouts/awardees.html
+++ b/_layouts/awardees.html
@@ -63,7 +63,7 @@ class: awardees-layout
   <div class="usa-grid">
     <div class="usa-accordion awardees-details-accordion">
     {% for topic in site.data.tech-topics %}
-      {% assign po_name = topic.programDirector[0].api_name | default: topic.programDirector[0].last_name %}
+      {% assign po_name = topic.programDirector[0].api_name | default: topic.programDirector[0].api_name %}
       {% assign matching_awards = site.data[page.dataset] | uniq | where:'poName', po_name | sort_insensitive:'awardeeName' %}
       {% if matching_awards.size > 0 %}
         <div class="border-bottom">

--- a/_layouts/awardees.html
+++ b/_layouts/awardees.html
@@ -63,7 +63,7 @@ class: awardees-layout
   <div class="usa-grid">
     <div class="usa-accordion awardees-details-accordion">
     {% for topic in site.data.tech-topics %}
-      {% assign po_name = topic.programDirector[0].api_name | default: topic.programDirector[0].api_name %}
+      {% assign po_name = topic.programDirector[0].api_name %}
       {% assign matching_awards = site.data[page.dataset] | uniq | where:'poName', po_name | sort_insensitive:'awardeeName' %}
       {% if matching_awards.size > 0 %}
         <div class="border-bottom">


### PR DESCRIPTION
Fixes issue(s) # 940.

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/eaTopic/)

Changes proposed in this pull request:
-Luckily, there was already a field that was being used for some of the names called "api_name". So instead of creating a whole new field, I just added it as a required field and made a small adjustment to the awards page display. 
If you compare the preview:
https://federalist-proxy.app.cloud.gov/preview/18f/nsf-sbir/eaTopic/awardees/phase-1/
with the current display:
https://seedfund.nsf.gov/awardees/phase-1/
everything should look the same except the number of EA topics, as the list should now show Larsen's awards.

/cc @relevant-people
