### PR TITLE
Update compensation for local panelists" on travel.md

### DIFF
--- a/pages/resources/review/travel.md
+++ b/pages/resources/review/travel.md
@@ -28,11 +28,7 @@ The flat rate payment covers lodging, meals, parking, local transportation and m
 
 ## Compensation for Local Panelists
 
-Participants who are not federal government employees and are US citizens or US permanent residents and **reside in the Washington-Metropolitan area**, which includes
-
-1. Maryland counties of Prince Georges and Montgomery
-2. Virginia counties of Arlington, Loudoun and Fairfax
-3. Cities of Washington, DC,Alexandria, Falls Church, and Fairfax
+Participants who are not federal government employees and are US citizens or US permanent residents and **reside within 35 miles of the National Science Foundation headquarters at 2415 Eisenhower Avenue, Alexandria, VA  22314.**
 
 The flat rate payment for local panelists is $280 per day. Real Time Conferencing (virtual) participants are eligible to receive $200 per day.
 


### PR DESCRIPTION
Fixes issue(s) #1032 . @seakhtar @CecileGonzalez 

The section “Compensation for Local Panelists” ( https://seedfund.nsf.gov/resources/review/travel/) currently lists counties but recently NSF changed the definition of “local” to within 35 miles of the meeting location.
Change to: Participants who are not federal government employees and are US citizens or US permanent residents and reside within 35 miles of the National Science Foundation headquarters at 2415 Eisenhower Avenue, Alexandria, VA 22314.
