### PR TITLE
Fixed investment numbers

### DIFF
--- a/pages/portfolio.md
+++ b/pages/portfolio.md
@@ -20,7 +20,7 @@ scripts:
 <div class="usa-section usa-content usa-grid" markdown="1">
 
 # Portfolio
-Since 2012, America’s Seed Fund powered by NSF has made nearly 2,500 awards to startups and small businesses. Since 2010, our awardees have had 62 exits and have received $3.2 billion in private investment. We encourage you to explore this list of assorted companies we've funded.
+Since 2012, America’s Seed Fund powered by NSF has made more than 2,500 awards to startups and small businesses. Since 2014, our awardees have had 70 exits and have received $3.5 billion in private investment. We encourage you to explore this list of assorted companies we've funded.
 
 
 <form onsubmit="allAwards(this.a1.value); return false;" class="awards-search-form">


### PR DESCRIPTION
Added the updated portfolio information - $3.5B in investment and 70 exits since 2014. Also, said more than 2,500 companies instead of nearly 2,500 companies.