### PR TITLE
Phase II VRS instructions

### DIFF
--- a/pages/resources/awardees/phase-2/instructions.md
+++ b/pages/resources/awardees/phase-2/instructions.md
@@ -25,13 +25,13 @@ From the [FastLane homepage](http://www.fastlane.nsf.gov) select:
                 2. If your company did not submit the [NSF Funding Agreement]({{site.baseurl}}/assets/files/awardees/SBIR_STTR_Funding_Agreement.pdf) with your original proposal, you will need to fill one out, sign and submit with your supplement request.  The NSF Funding Agreement must be included in Supplementary Documents and you will need to include a statement in the budget justification that you have uploaded the Funding Agreement. The budget justification statement can be  
             - “The completed and signed Certification Form has been included in Supplementary Documents”.  
     - Include a statement indicating that all the budget rates in the supplement budget do not exceed those in the original award (include award number).  
-3. **RAHSS/REU/RET/VRS Budget Info**: All student/teacher costs are entered under line F as participant support costs.  
+3. **RAHSS/REU/RET/VRS/CAP Budget Info**: All student/teacher costs are entered under line F as participant support costs.  
     - REU bottom line for the overall budget is either $8,000 for one student or $16,000 for two. (Funds should only appear on budget line F.1)  
     - RAHSS bottom line for the overall budget is either $6,000 for one student or $12,000 for two. (Funds should only appear on budget line F.1)  
     - RET bottom line for the overall budget is either $10,000 for one teacher or $20,000 for two. **Note** The total cost of an RET supplement is limited to $10,000 per teacher per year.  For both RET Site and RET Supplement, the budget includes a teacher and/or community college faculty stipend of up to $2,000 for the cost of materials, equipment, software and other supplies for developing classroom instructions and experiments. (Funds should only appear on budget lines F.1 and F.4, respectively).  
     - VRS bottom line for the overall budget is either $10,000 for one, $20,000 for two, or $30,000 for three. (Funds should only appear on budget line F.1)  
-          - **CAP Budget Info**: All costs allocated to the service provider are entered under line G.6 as "other costs".  
-          - **For all other supplements**: please refer to the DCL for budgetary guidance.  
+    - **CAP Budget Info**: All costs allocated to the service provider are entered under line G.6 as "other costs".  
+    - **For all other supplements**: please refer to the DCL for budgetary guidance.  
     - GO Explanation for Late Request: Provide the reason for the late request. (If Applicable; Phase IICC , RAHSS, REU and RET supplements are not permitted to extend the end date of the award).  
     - GO Revised Expiration Date (if applicable): Provide the number of additional months requested for this award (no more than 1 year). `Always check with your Program Director before adding any additional time.`  
     - GO Add/Delete Non Co-PI Senior Personnel: Add the name(s) of the person(s) whom you wish to enter as Senior Personnel on this award. To delete an existing Senior Person highlight the name in the list box where it says "Select a name to remove as a Senior Personnel" and click on "Delete Non Co-PI Senior Person From Proposal".  


### PR DESCRIPTION
Fix. 
On this page, under item 3 – there are two items that need to have their own bullets under the VRS bullet.  It is confusing because these are not sub-bullets to VRS but standalone statements.
https://seedfund.nsf.gov/resources/awardees/phase-2/instructions/

•	VRS bottom line for the overall budget is either $10,000 for one, $20,000 for two, or $30,000 for three. (Funds should only appear on budget line F.1)
- CAP Budget Info: All costs allocated to the service provider are entered under line G.6 as “other costs”.
- For all other supplements: please refer to the DCL for budgetary guidance.

And the header for #3 should be modified to include “CAP” like  RAHSS/REU/RET/VRS/CAP Budget Info

Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
-
-
-

/cc @relevant-people
