### PR TITLE
Clarified Fastlane v Research.gov

### DIFF
--- a/_timeline/step-7.md
+++ b/_timeline/step-7.md
@@ -7,4 +7,6 @@ inactive_description: Though we're not currently accepting applications, we enco
 
 ### [Start your application in FastLane](https://www.fastlane.nsf.gov/jsp/homepage/proposals.jsp)
 
+NSF is transitioning to a new proposal processing system on Research.gov. You'll need to register in [Research.gov]( https://www.research.gov/research-portal/appmanager/base/desktop?_nfpb=true&_pageLabel=research_home_page) and go to FastLane to upload your proposal. Research.gov is NOT yet accepting SBIR and STTR proposals. 
+
 Before you start your application, take a look at our [FastLane guide]({{ site.baseurl }}/fastlane/) or [download our FastLane guide]({{ site.baseurl }}/assets/files/applicants/Phase_I_Proposal_Preparation_Booklet.pdf) for detailed steps on how to submit your application and [watch our video on how to apply](https://www.youtube.com/watch?v=sCkBRbQxLx0&feature=youtu.be).


### PR DESCRIPTION
Hello,

I just wanted to bring to your attention that we have started to receive some emails from submitters that are trying to submit to the SBIR program via Research.Gov.  

Although the FastLane guide you provided to them on the Seedfund site states to go to FastLane, there is still some confusion and some submitters are going to Research.Gov.  I was thinking maybe if adding something to the Advisory on Fastlane or the Seedfund site splash page advising applicants to only use Fastlane would steer them in the right direction.

I think closer and closer we get to the deadline we are going to get more emails and calls from applicants trying to use Research.Gov for submission.

Either way I just wanted you to know what type of calls we have been seeing.

Thanks,

Jorge Urrutia – Technical Support  (contractor)
IT Help Central Services

Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/nsf-sbir/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/nsf-sbir/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
-
-
-

/cc @relevant-people
